### PR TITLE
Support Azure Functions V4 for python3.10.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-functions/python:4-python3.9
+FROM mcr.microsoft.com/azure-functions/python:4-python3.10
 
 # 0. Install essential packages
 RUN apt-get update \

--- a/HttpTrigger/__init__.py
+++ b/HttpTrigger/__init__.py
@@ -2,6 +2,7 @@ import logging
 
 import azure.functions as func
 from selenium import webdriver
+from selenium.webdriver.common.by import By
 from azure.identity import DefaultAzureCredential, ClientSecretCredential
 from azure.storage.blob import BlobServiceClient
 from datetime import datetime
@@ -17,7 +18,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
 
     driver = webdriver.Chrome("/usr/local/bin/chromedriver", chrome_options=chrome_options)
     driver.get('http://www.ubuntu.com/')
-    links = driver.find_elements_by_tag_name("a")
+    links = driver.find_elements(By.TAG_NAME, "a")
     link_list = ""
     for link in links:
         if link_list == "":

--- a/TimeTrigger/__init__.py
+++ b/TimeTrigger/__init__.py
@@ -3,9 +3,10 @@ import logging
 
 import azure.functions as func
 from selenium import webdriver
+from selenium.webdriver.common.by import By
 from azure.identity import DefaultAzureCredential, ClientSecretCredential
 from azure.storage.blob import BlobServiceClient
-from datetime import datetime
+import datetime
 import os
 
 def main(mytimer: func.TimerRequest) -> None:
@@ -24,7 +25,7 @@ def main(mytimer: func.TimerRequest) -> None:
 
     driver = webdriver.Chrome("/usr/local/bin/chromedriver", chrome_options=chrome_options)
     driver.get('http://www.ubuntu.com/')
-    links = driver.find_elements_by_tag_name("a")
+    links = driver.find_elements(By.TAG_NAME, "a")
     link_list = ""
     for link in links:
         if link_list == "":
@@ -36,6 +37,6 @@ def main(mytimer: func.TimerRequest) -> None:
     credential = DefaultAzureCredential()
     storage_account_url = "https://" + os.environ["par_storage_account_name"] + ".blob.core.windows.net"
     client = BlobServiceClient(account_url=storage_account_url, credential=credential)
-    blob_name = "test" + str(datetime.now()) + ".txt"
+    blob_name = "test" + str(datetime.datetime.now()) + ".txt"
     blob_client = client.get_blob_client(container=os.environ["par_storage_container_name"], blob=blob_name)
     blob_client.upload_blob(link_list)


### PR DESCRIPTION
## Feature
- Support Azure Functions V4 for python3.10.
- Fix HTTP Trigger code that support after Selenium 4.3.0 to use `find_elements` syntax.
    - https://www.selenium.dev/documentation/webdriver/elements/finders/#all-matching-elements  
    - https://github.com/SeleniumHQ/selenium/blob/a4995e2c096239b42c373f26498a6c9bb4f2b3e7/py/CHANGES

```
Selenium 4.3.0
* Deprecated find_element_by_* and find_elements_by_* are now removed (#10712)
```

- Fix Timer Trigger Code that support after Selenium 4.3.0 to use `find_elements` syntax and how to use datetime module.