### PR TITLE
Update Dockerfile to pull latest versions of chromedriver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
         wget \
         unzip \
         unixodbc-dev \
+        jq \
     && rm -rf /var/lib/apt/lists/*
 
 # 1. Install Chrome (root image is debian)
@@ -23,9 +24,10 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # 2. Install Chrome driver used by Selenium
-RUN LATEST=$(wget -q -O - http://chromedriver.storage.googleapis.com/LATEST_RELEASE) && \
-    wget http://chromedriver.storage.googleapis.com/$LATEST/chromedriver_linux64.zip && \
-    unzip chromedriver_linux64.zip && ln -s $PWD/chromedriver /usr/local/bin/chromedriver
+RUN LATEST=$(wget -q -O - https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json \
+ | jq -r '.channels.Stable.downloads.chrome[] | select(.platform=="linux64").url') \ 
+  && wget $LATEST \
+  && unzip chrome-linux64.zip && ln -s $PWD/chromedriver /usr/local/bin/chromedriver
 
 ENV PATH="/usr/local/bin/chromedriver:${PATH}"
 


### PR DESCRIPTION
http://chromedriver.storage.googleapis.com/LATEST_RELEASE was no longer maintained after v114, so as we are downloading the latest stable build of chrome browser the driver was stuck on an incompatible v114. From v115+ latest versions and download links were moved to https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json. 

There are alternative builds to choose from here: https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints